### PR TITLE
:wrench: inheritance issue from Component

### DIFF
--- a/Saint-Nec-Engine/Saint-Nec-Engine-Lib/src/architecture/Component.cpp
+++ b/Saint-Nec-Engine/Saint-Nec-Engine-Lib/src/architecture/Component.cpp
@@ -1,1 +1,7 @@
 #include "Component.hpp"
+
+
+namespace saintNecEngine{
+
+    Component::~Component() {}
+}


### PR DESCRIPTION
We need to implement the constructeur in the cpp file to avoid [issue](https://github.com/antonindevidal/Saint-Nec-Engine/issues/11) from inheritance classes. This implementation keep this class  abstract.